### PR TITLE
Test CRDT semantics with TestBucket_Merge

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -93,7 +93,8 @@ func TestBucket_Merge(t *testing.T) {
 
 		random := buckets[rng.Int()%len(buckets)]
 		for _, bucket := range buckets {
-			random.Merge(&bucket)
+			// Explicitly test idempotence by merging the same bucket twice.
+			random.Merge(&bucket, &bucket)
 		}
 
 		if random != sequential {


### PR DESCRIPTION
This PR adds a test to verify that the CRDT semantics of a Bucket are implemented correctly.

PTAL @peterbourgon