### PR TITLE
Avoid need for cluster clock synchronization

### DIFF
--- a/api.go
+++ b/api.go
@@ -14,14 +14,15 @@ import (
 
 // API implements the Patrol service HTTP API.
 type API struct {
-	log  *log.Logger
-	repo Repo
+	log   *log.Logger
+	clock func() time.Time
+	repo  Repo
 	http.Handler
 }
 
 // NewAPI returns a new Patrol API.
-func NewAPI(l *log.Logger, repo Repo) *API {
-	api := API{log: l, repo: repo}
+func NewAPI(l *log.Logger, clock func() time.Time, repo Repo) *API {
+	api := API{log: l, clock: clock, repo: repo}
 
 	rt := httprouter.New()
 	rt.HandlerFunc("POST", "/take/:name", api.takeBucket)
@@ -70,7 +71,7 @@ func (api *API) takeBucket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	code := http.StatusOK
-	if !bucket.Take(time.Now(), rate, count) {
+	if !bucket.Take(api.clock(), rate, count) {
 		code = http.StatusTooManyRequests
 	}
 

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -8,7 +8,13 @@ import (
 )
 
 func TestBucket_Marshaling(t *testing.T) {
-	prop := func(b Bucket) bool {
+	prop := func(name string, added, taken float64, elapsed time.Duration) bool {
+		b := Bucket{
+			Name:    name,
+			Added:   added,
+			Taken:   taken,
+			Elapsed: elapsed,
+		}
 		data, err := b.MarshalBinary()
 		if err != nil {
 			t.Fatal(err)
@@ -29,7 +35,7 @@ func TestBucket_Marshaling(t *testing.T) {
 func TestBucket_Take(t *testing.T) {
 	rate := Rate{Freq: 60, Per: time.Second} // 60 tokens per second
 	interval := rate.Interval()
-	bucket := NewBucket(60)
+	bucket := NewBucket(5) // 5 initial tokens
 	now := time.Unix(0, 0)
 
 	// Test successive takes from the same bucket.
@@ -65,9 +71,9 @@ func TestBucket_Merge(t *testing.T) {
 	buckets := make([]Bucket, 100)
 	for i := range buckets {
 		buckets[i] = Bucket{
-			Added: rng.Float64(), // The P of the PN counter "tokens".
-			Taken: rng.Float64(), // The N of the PN counter "tokens".
-			Last:  rng.Int63(),   // A separate "last" timestamp G-Counter.
+			Added:   rng.Float64(),              // The P of the PN counter "tokens".
+			Taken:   rng.Float64(),              // The N of the PN counter "tokens".
+			Elapsed: time.Duration(rng.Int63()), // A separate "elapsed" duration G-Counter.
 		}
 	}
 

--- a/cmd/patrol/main.go
+++ b/cmd/patrol/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/tsenart/patrol"
 )
@@ -17,15 +18,22 @@ func main() {
 		APIAddr:          "0.0.0.0:8080",
 		ReplicatorAddr:   "0.0.0.0:16000",
 		ClusterDiscovery: "static",
+		ShutdownTimeout:  30 * time.Second,
 	}
 
+	var offset time.Duration
 	fs := flag.NewFlagSet("patrol", flag.ExitOnError)
 	fs.StringVar(&cmd.APIAddr, "api-addr", cmd.APIAddr, "Address to bind HTTP API to")
 	fs.StringVar(&cmd.ReplicatorAddr, "replicator-addr", cmd.ReplicatorAddr, "Address to bind replication server to")
 	fs.StringVar(&cmd.ClusterDiscovery, "cluster-discovery", cmd.ClusterDiscovery, "Cluster discovery [static]")
+	fs.DurationVar(&offset, "time-offset", 0, "Time offset to add to clock timestamps (for testing)")
 	fs.Var(&nodeFlag{nodes: &cmd.ClusterNodes}, "cluster-node", "Cluster node to broadcast to")
 
 	fs.Parse(os.Args[1:])
+
+	cmd.Clock = func() time.Time {
+		return time.Now().UTC().Add(offset)
+	}
 
 	if err := cmd.Run(context.Background()); err != nil {
 		cmd.Log.Fatal(err)

--- a/replicator.go
+++ b/replicator.go
@@ -22,7 +22,11 @@ func NewReplicator(log *log.Logger, repo Repo, addr string) (*Replicator, error)
 	if err != nil {
 		return nil, err
 	}
-	return &Replicator{log: log, repo: repo, conn: conn}, nil
+	return &Replicator{
+		log:  log,
+		repo: repo,
+		conn: conn,
+	}, nil
 }
 
 // Start satarts the replicator server, consuming and applying UDP message


### PR DESCRIPTION
This PR changes the `Bucket` CRDT to avoid the need for clock synchronization (e.g via ntpd) on cluster nodes.